### PR TITLE
Specify MySQL Docker Image OS

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0
+FROM mysql:8.0-debian
 
 # Workaround: https://github.com/docker-library/mysql/issues/811
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29


### PR DESCRIPTION
## 概要
MySQLにおけるDocker ImageのOSを指定する

## Issue
- None

## 詳細
DockerのデフォルトOSが変更されたことに対応して、MySQLにおけるDocker ImageのOSを指定する

## 影響範囲
小

## 補足
何かあれば
