### PR TITLE
TLM DBとCMD DBのエンコードをUTF-8にする

### DIFF
--- a/aspnetapp/WINGS/Data/CommandDbRepository.cs
+++ b/aspnetapp/WINGS/Data/CommandDbRepository.cs
@@ -119,7 +119,7 @@ namespace WINGS.Data
       {
         case TlmCmdFileLocation.Local:
           Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-          return Task.FromResult(new StreamReader(filePath, Encoding.GetEncoding("shift-jis")));
+          return Task.FromResult(new StreamReader(filePath, Encoding.GetEncoding("utf-8")));
         default:
           throw new ArgumentException("Undefined file location");
       }

--- a/aspnetapp/WINGS/Data/TelemetryDbRepository.cs
+++ b/aspnetapp/WINGS/Data/TelemetryDbRepository.cs
@@ -221,7 +221,7 @@ namespace WINGS.Data
       {
         case TlmCmdFileLocation.Local:
           Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-          return Task.FromResult(new StreamReader(filePath, Encoding.GetEncoding("shift-jis")));
+          return Task.FromResult(new StreamReader(filePath, Encoding.GetEncoding("utf-8")));
         default:
           throw new ArgumentException("Undefined file location");
       }


### PR DESCRIPTION
## 概要
TLM DBとCMD DBのエンコードをUTF-8にする

## Issue
- N/A


