### PR TITLE
[hotfix] SetValueの修正

### DIFF
--- a/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
+++ b/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
@@ -165,7 +165,7 @@ namespace WINGS.Services
           UInt16 mask = (UInt16)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt16 raw = (UInt16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos + 1]);
           UInt16 defraw = (UInt16)((UInt16)(raw & mask) >> (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         else
@@ -173,7 +173,7 @@ namespace WINGS.Services
           UInt32 mask = (UInt32)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
           UInt32 defraw = (UInt32)((UInt32)(raw & mask) >> (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         // support bytenum > 1 (e.g.: BitPos = 0, 8 < BitLen < 15)
@@ -204,7 +204,7 @@ namespace WINGS.Services
       }
     }
 
-    private string ConvertValue<T>(T raw, Telemetry tlm, Byte bitlen)
+    private string ConvertValue<T>(T raw, Telemetry tlm)
     {
       switch (tlm.TelemetryInfo.ConvType)
       {
@@ -236,14 +236,14 @@ namespace WINGS.Services
           }
         
         case "HEX":
-          return HexConvertValue(raw, tlm, bitlen);
+          return HexConvertValue(raw, tlm);
 
         default:
           throw new Exception("Undefined conversion type");
       }      
     }
 
-    private string HexConvertValue<T>(T raw, Telemetry tlm, Byte bitlen)
+    private string HexConvertValue<T>(T raw, Telemetry tlm)
     {
       string hexraw;
       switch (tlm.TelemetryInfo.Type)

--- a/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
+++ b/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
@@ -106,7 +106,7 @@ namespace WINGS.Services
           case "int16_t":
           case "int16":
           {
-            Int16 raw = (Int16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos+1]);
+            Int16 raw = (Int16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos + 1]);
             tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
@@ -114,7 +114,7 @@ namespace WINGS.Services
           case "uint32_t":
           case "uint32":
           {
-            UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos+1] << 16 | packet[tlm.TelemetryInfo.OctetPos+2] << 8 | packet[tlm.TelemetryInfo.OctetPos+3]);
+            UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
             tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
@@ -122,14 +122,14 @@ namespace WINGS.Services
           case "int32_t":
           case "int32":
           {
-            Int32 raw = (Int32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos+1] << 16 | packet[tlm.TelemetryInfo.OctetPos+2] << 8 | packet[tlm.TelemetryInfo.OctetPos+3]);
+            Int32 raw = (Int32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
             tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
           case "float":
           {
-            var temp = new byte[]{packet[tlm.TelemetryInfo.OctetPos+3], packet[tlm.TelemetryInfo.OctetPos+2], packet[tlm.TelemetryInfo.OctetPos+1], packet[tlm.TelemetryInfo.OctetPos]};
+            var temp = new byte[]{packet[tlm.TelemetryInfo.OctetPos + 3], packet[tlm.TelemetryInfo.OctetPos + 2], packet[tlm.TelemetryInfo.OctetPos + 1], packet[tlm.TelemetryInfo.OctetPos]};
             Single raw = BitConverter.ToSingle(temp, 0);
             tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
             tlm.TelemetryValue.RawValue = raw.ToString();
@@ -137,8 +137,8 @@ namespace WINGS.Services
           }
           case "double":
           {
-            var temp = new byte[]{packet[tlm.TelemetryInfo.OctetPos+7], packet[tlm.TelemetryInfo.OctetPos+6], packet[tlm.TelemetryInfo.OctetPos+5], packet[tlm.TelemetryInfo.OctetPos+4],
-                                  packet[tlm.TelemetryInfo.OctetPos+3], packet[tlm.TelemetryInfo.OctetPos+2], packet[tlm.TelemetryInfo.OctetPos+1], packet[tlm.TelemetryInfo.OctetPos]};
+            var temp = new byte[]{packet[tlm.TelemetryInfo.OctetPos + 7], packet[tlm.TelemetryInfo.OctetPos + 6], packet[tlm.TelemetryInfo.OctetPos + 5], packet[tlm.TelemetryInfo.OctetPos + 4],
+                                  packet[tlm.TelemetryInfo.OctetPos + 3], packet[tlm.TelemetryInfo.OctetPos + 2], packet[tlm.TelemetryInfo.OctetPos + 1], packet[tlm.TelemetryInfo.OctetPos]};
             Double raw = BitConverter.ToDouble(temp, 0);
             tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
             tlm.TelemetryValue.RawValue = raw.ToString();
@@ -153,10 +153,29 @@ namespace WINGS.Services
       else
       {
         // int bytenum = (tlm.TelemetryInfo.BitPos + tlm.TelemetryInfo.BitLen - 1) / 8 + 1;
-        Byte defraw;
-        Byte mask;
-        mask = (Byte)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (8 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-        defraw = (Byte)((UInt16)(packet[tlm.TelemetryInfo.OctetPos] & mask) >> (8 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+        if (tlm.TelemetryInfo.BitLen < 9)
+        {
+          Byte mask = (Byte)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (8 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          Byte defraw = (Byte)((Byte)(packet[tlm.TelemetryInfo.OctetPos] & mask) >> (8 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.RawValue = defraw.ToString();
+        }
+        else if (tlm.TelemetryInfo.BitLen < 17) 
+        {
+          UInt16 mask = (UInt16)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          UInt16 raw = (UInt16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos + 1]);
+          UInt16 defraw = (UInt16)((UInt16)(raw & mask) >> (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.RawValue = defraw.ToString();
+        }
+        else
+        {
+          UInt32 mask = (UInt32)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
+          UInt32 defraw = (UInt32)((UInt32)(raw & mask) >> (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.RawValue = defraw.ToString();
+        }
         // support bytenum > 1 (e.g.: BitPos = 0, 8 < BitLen < 15)
         /*
         if (bytenum != 1)
@@ -182,8 +201,6 @@ namespace WINGS.Services
           }
         }
         */
-        tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
-        tlm.TelemetryValue.RawValue = defraw.ToString();
       }
     }
 

--- a/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
+++ b/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
@@ -83,7 +83,7 @@ namespace WINGS.Services
           case "uint8":
           {
             Byte raw = (Byte)packet[tlm.TelemetryInfo.OctetPos];
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -91,7 +91,7 @@ namespace WINGS.Services
           case "int8":
           {
             SByte raw = (SByte)packet[tlm.TelemetryInfo.OctetPos];
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -99,7 +99,7 @@ namespace WINGS.Services
           case "uint16":
           {
             UInt16 raw = (UInt16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos+1]);
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -107,7 +107,7 @@ namespace WINGS.Services
           case "int16":
           {
             Int16 raw = (Int16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos + 1]);
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -115,7 +115,7 @@ namespace WINGS.Services
           case "uint32":
           {
             UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -123,7 +123,7 @@ namespace WINGS.Services
           case "int32":
           {
             Int32 raw = (Int32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -131,7 +131,7 @@ namespace WINGS.Services
           {
             var temp = new byte[]{packet[tlm.TelemetryInfo.OctetPos + 3], packet[tlm.TelemetryInfo.OctetPos + 2], packet[tlm.TelemetryInfo.OctetPos + 1], packet[tlm.TelemetryInfo.OctetPos]};
             Single raw = BitConverter.ToSingle(temp, 0);
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -140,7 +140,7 @@ namespace WINGS.Services
             var temp = new byte[]{packet[tlm.TelemetryInfo.OctetPos + 7], packet[tlm.TelemetryInfo.OctetPos + 6], packet[tlm.TelemetryInfo.OctetPos + 5], packet[tlm.TelemetryInfo.OctetPos + 4],
                                   packet[tlm.TelemetryInfo.OctetPos + 3], packet[tlm.TelemetryInfo.OctetPos + 2], packet[tlm.TelemetryInfo.OctetPos + 1], packet[tlm.TelemetryInfo.OctetPos]};
             Double raw = BitConverter.ToDouble(temp, 0);
-            tlm.TelemetryValue.Value = ConvertValue(raw, tlm);
+            tlm.TelemetryValue.Value = ConvertValue(raw, tlm, tlm.TelemetryInfo.BitLen);
             tlm.TelemetryValue.RawValue = raw.ToString();
             break;
           }
@@ -157,7 +157,7 @@ namespace WINGS.Services
         {
           Byte mask = (Byte)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (8 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           Byte defraw = (Byte)((Byte)(packet[tlm.TelemetryInfo.OctetPos] & mask) >> (8 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         else if (tlm.TelemetryInfo.BitLen < 17) 
@@ -165,7 +165,7 @@ namespace WINGS.Services
           UInt16 mask = (UInt16)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt16 raw = (UInt16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos + 1]);
           UInt16 defraw = (UInt16)((UInt16)(raw & mask) >> (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         else
@@ -173,7 +173,7 @@ namespace WINGS.Services
           UInt32 mask = (UInt32)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
           UInt32 defraw = (UInt32)((UInt32)(raw & mask) >> (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         // support bytenum > 1 (e.g.: BitPos = 0, 8 < BitLen < 15)
@@ -204,7 +204,7 @@ namespace WINGS.Services
       }
     }
 
-    private string ConvertValue<T>(T raw, Telemetry tlm)
+    private string ConvertValue<T>(T raw, Telemetry tlm, int bitlen)
     {
       switch (tlm.TelemetryInfo.ConvType)
       {
@@ -236,14 +236,14 @@ namespace WINGS.Services
           }
         
         case "HEX":
-          return HexConvertValue(raw, tlm);
+          return HexConvertValue(raw, tlm, bitlen);
 
         default:
           throw new Exception("Undefined conversion type");
       }      
     }
 
-    private string HexConvertValue<T>(T raw, Telemetry tlm)
+    private string HexConvertValue<T>(T raw, Telemetry tlm, int bitlen)
     {
       string hexraw;
       switch (tlm.TelemetryInfo.Type)
@@ -291,24 +291,25 @@ namespace WINGS.Services
           return hexraw;
         }
         default:
-          if (Convert.ToUInt32(raw) < 0x100)
+          if (bitlen < 9)
           {
             SByte sbyteraw =  Convert.ToSByte(raw);
             hexraw = "0x" + sbyteraw.ToString("x2");
             return hexraw;
           }
-          else if (Convert.ToUInt32(raw) < 0x10000)
+          else if (bitlen < 17)
           {
             UInt16 uint16raw =  Convert.ToUInt16(raw);
             hexraw = "0x" + uint16raw.ToString("x4");
             return hexraw;
           }
-          else
+          else if (bitlen < 33)
           {
             UInt32 uint32raw = Convert.ToUInt32(raw);
             hexraw = "0x" + uint32raw.ToString("x8");
             return hexraw;
           }
+          throw new Exception("Unsupported data types for hexadecimal conversion");
       }
     }
 

--- a/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
+++ b/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
@@ -170,9 +170,9 @@ namespace WINGS.Services
         }
         else
         {
-          UInt32 mask = (UInt32)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          UInt32 mask = (UInt32)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
-          UInt32 defraw = (UInt32)((UInt32)(raw & mask) >> (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
+          UInt32 defraw = (UInt32)((UInt32)(raw & mask) >> (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }

--- a/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
+++ b/aspnetapp/WINGS/Services/TMTC/Processor/Abstracts/TmPacketAnalyzerBase.cs
@@ -165,7 +165,7 @@ namespace WINGS.Services
           UInt16 mask = (UInt16)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt16 raw = (UInt16)(packet[tlm.TelemetryInfo.OctetPos] << 8 | packet[tlm.TelemetryInfo.OctetPos + 1]);
           UInt16 defraw = (UInt16)((UInt16)(raw & mask) >> (16 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         else
@@ -173,7 +173,7 @@ namespace WINGS.Services
           UInt32 mask = (UInt32)(((1 << tlm.TelemetryInfo.BitLen) - 1) << (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
           UInt32 raw = (UInt32)(packet[tlm.TelemetryInfo.OctetPos] << 24 | packet[tlm.TelemetryInfo.OctetPos + 1] << 16 | packet[tlm.TelemetryInfo.OctetPos + 2] << 8 | packet[tlm.TelemetryInfo.OctetPos + 3]);
           UInt32 defraw = (UInt32)((UInt32)(raw & mask) >> (32 - tlm.TelemetryInfo.BitPos - tlm.TelemetryInfo.BitLen));
-          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm);
+          tlm.TelemetryValue.Value = ConvertValue(defraw, tlm, tlm.TelemetryInfo.BitLen);
           tlm.TelemetryValue.RawValue = defraw.ToString();
         }
         // support bytenum > 1 (e.g.: BitPos = 0, 8 < BitLen < 15)
@@ -204,7 +204,7 @@ namespace WINGS.Services
       }
     }
 
-    private string ConvertValue<T>(T raw, Telemetry tlm)
+    private string ConvertValue<T>(T raw, Telemetry tlm, Byte bitlen)
     {
       switch (tlm.TelemetryInfo.ConvType)
       {
@@ -236,14 +236,14 @@ namespace WINGS.Services
           }
         
         case "HEX":
-          return HexConvertValue(raw, tlm);
+          return HexConvertValue(raw, tlm, bitlen);
 
         default:
           throw new Exception("Undefined conversion type");
       }      
     }
 
-    private string HexConvertValue<T>(T raw, Telemetry tlm)
+    private string HexConvertValue<T>(T raw, Telemetry tlm, Byte bitlen)
     {
       string hexraw;
       switch (tlm.TelemetryInfo.Type)
@@ -291,7 +291,24 @@ namespace WINGS.Services
           return hexraw;
         }
         default:
-          throw new Exception("Unsupported data types for hexadecimal conversion");
+          if (Convert.ToUInt32(raw) < 0x100)
+          {
+            SByte sbyteraw =  Convert.ToSByte(raw);
+            hexraw = "0x" + sbyteraw.ToString("x2");
+            return hexraw;
+          }
+          else if (Convert.ToUInt32(raw) < 0x10000)
+          {
+            UInt16 uint16raw =  Convert.ToUInt16(raw);
+            hexraw = "0x" + uint16raw.ToString("x4");
+            return hexraw;
+          }
+          else
+          {
+            UInt32 uint32raw = Convert.ToUInt32(raw);
+            hexraw = "0x" + uint32raw.ToString("x8");
+            return hexraw;
+          }
       }
     }
 


### PR DESCRIPTION
## 概要
[hotfix] SetValueの修正

## Issue
- N/A

## 詳細
- SetTelemetryValuesAsyncにおいて，`TypeTlmLenCheck(tlm.TelemetryInfo.Type, tlm.TelemetryInfo.BitLen)`がfalseの時にテレメの値を`UInt16`や`UInt32`に変換する箇所が誤っているため修正．

