### PR TITLE
fix realtime flag

### DIFF
--- a/aspnetapp/WINGS/Services/TMTC/Processor/UserDefined/MOBC/MobcTmPacketAnalyzer.cs
+++ b/aspnetapp/WINGS/Services/TMTC/Processor/UserDefined/MOBC/MobcTmPacketAnalyzer.cs
@@ -211,15 +211,14 @@ namespace WINGS.Services
     }
     private bool GetRealTimeFlag(byte[] packet)
     {
-      //packet : CCSDS Packet
-      int pos = 10;
-      if ((packet[pos] & 0b_1110_0000) == 0b_0000_0000) // rp
-      {
-        return false;
-      }
-      else  // HK or MS( or stored)
+      int pos = 24;
+      if ((packet[pos] & 0b00000011) != 0)
       {
         return true;
+      }
+      else  // 0b00000001 or 0b00000010 -> realtime telemetry
+      {
+        return false;
       }
     }
     private UInt32 GetTI(byte[] packet)


### PR DESCRIPTION
## 概要
テレメのrealtimeflagの取得位置が誤っていたため修正

## Issue
N/A

## 詳細
テレメログのcsvファイルから、TIが特定の値の時にテレメが抜ける現象が発生。 該当のテレメがDR再生のログにのみに保存されることが原因だったため修正。

## 検証結果
SILSで検証済み

## 影響範囲
中

## 補足
何かあれば

## 注意