### PR TITLE
node moduleアプデに伴い崩れたcssを修正

### DIFF
--- a/aspnetapp/WINGS/ClientApp/src/components/telemetry/view_display/ViewDisplayBlock.tsx
+++ b/aspnetapp/WINGS/ClientApp/src/components/telemetry/view_display/ViewDisplayBlock.tsx
@@ -32,7 +32,7 @@ const ViewDisplayContent = styled('div')(({ theme }) => ({
   borderWidth: "0px 1px 1px 1px"
 }));
 
-const DisplayTab = styled(Tab)(({}) => ({
+const DisplayTab = styled(Tab)({
   width: '100%',
   minHeight: "auto",
   textAlign: "left",
@@ -59,9 +59,9 @@ const DisplayTab = styled(Tab)(({}) => ({
     textOverflow: "ellipsis",
     overflow: "hidden",
     display: "inline-block",
-    flexGrow: 1,
+    flexGrow: 1
   },
-}))
+})
 
 const a11yProps = (index: number) => {
   return {

--- a/aspnetapp/WINGS/ClientApp/src/components/telemetry/view_display/ViewDisplayBlock.tsx
+++ b/aspnetapp/WINGS/ClientApp/src/components/telemetry/view_display/ViewDisplayBlock.tsx
@@ -32,7 +32,7 @@ const ViewDisplayContent = styled('div')(({ theme }) => ({
   borderWidth: "0px 1px 1px 1px"
 }));
 
-const DisplayTab = styled(Tab)({
+const DisplayTab = styled(Tab)(({}) => ({
   width: '100%',
   minHeight: "auto",
   textAlign: "left",
@@ -41,31 +41,27 @@ const DisplayTab = styled(Tab)({
   padding: "0",
   border: 0,
   marginTop: 5,
-  "&.Mui-selected": {//選択されたタブのスタイル
+  "&.Mui-selected": {
     "& span": {
       color: "white"
     },
+    "& .MuiIconButton-root": {
+      color: "white"
+    }
+  },
   "& .MuiIconButton-root": {
-    color: "white"
-  }
-},
-"& .MuiIconButton-root": {//通常タブのスタイル
-  color: grey[300],
-  marginLeft: 0,
-},
-"& span": {//通常タブのスタイル
-  color: grey[300],
-  whiteSpace: "nowrap",
-  textOverflow: "ellipsis",
-  overflow: "hidden",
-  display: "inline-block",
-  flexGrow: 1,
-},
-});
-
-const StyledAddIcon = styled(AddIcon)({
-  marginTop: 5,
-});
+    color: grey[300],
+    marginLeft: 0,
+  },
+  "& span": {
+    color: grey[300],
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+    display: "inline-block",
+    flexGrow: 1,
+  },
+}))
 
 const a11yProps = (index: number) => {
   return {
@@ -127,9 +123,9 @@ const ViewDisplayBlock = (props: ViewDisplayBlockProps) => {
             />
           ))}
           <IconButtonInTabs onClick={handleDialogOpen}>
-            <StyledAddIcon
+            <AddIcon
               fontSize="small"
-              style={{ color: value === blockInfo.tabs.length ? "white" : grey[300] }}
+              style={{marginTop: 5, color: value === blockInfo.tabs.length ? "white" : grey[300] }}
               />
           </IconButtonInTabs>
         </Tabs>

--- a/aspnetapp/WINGS/ClientApp/src/components/telemetry/view_display/ViewDisplayBlock.tsx
+++ b/aspnetapp/WINGS/ClientApp/src/components/telemetry/view_display/ViewDisplayBlock.tsx
@@ -40,28 +40,32 @@ const DisplayTab = styled(Tab)({
   textOverflow: "ellipsis",
   padding: "0",
   border: 0,
-  "&.Mui-selected": {
+  marginTop: 5,
+  "&.Mui-selected": {//選択されたタブのスタイル
     "& span": {
       color: "white"
-    }
-  },
-  "& span": {
-    color: grey[300],
-    whiteSpace: "nowrap",
-    textOverflow: "ellipsis",
-    overflow: "hidden",
-    display: "inline-block",
-    flexGrow: 0
-  },
-  "& .MuiTab-wrapper > *:first-child": {
-    marginBottom: 0,
-    padding: 0,
-    marginRight: 15,
-    marginLeft: 5,
-    width: 20,
-    height: 20
+    },
+  "& .MuiIconButton-root": {
+    color: "white"
   }
-})
+},
+"& .MuiIconButton-root": {//通常タブのスタイル
+  color: grey[300],
+  marginLeft: 0,
+},
+"& span": {//通常タブのスタイル
+  color: grey[300],
+  whiteSpace: "nowrap",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  display: "inline-block",
+  flexGrow: 1,
+},
+});
+
+const StyledAddIcon = styled(AddIcon)({
+  marginTop: 5,
+});
 
 const a11yProps = (index: number) => {
   return {
@@ -123,7 +127,10 @@ const ViewDisplayBlock = (props: ViewDisplayBlockProps) => {
             />
           ))}
           <IconButtonInTabs onClick={handleDialogOpen}>
-            <AddIcon fontSize="small" />
+            <StyledAddIcon
+              fontSize="small"
+              style={{ color: value === blockInfo.tabs.length ? "white" : grey[300] }}
+              />
           </IconButtonInTabs>
         </Tabs>
       </AppBar>


### PR DESCRIPTION
## 概要
node moduleアプデに伴いテレメタブのcssが崩れていたので修正した


## Issue

## 詳細
* テキストとアイコンの位置を直した
* アイコンの色が選択にかかわらず常にグレーだったので直した
* あまりにも愚直に書いたのでいいやり方があれば教えてください

## 検証結果
修正前
![image](https://github.com/ut-issl/wings/assets/105411820/15bebc69-cd30-4059-b3bc-1a0a49f7f74c)

修正後
![image](https://github.com/ut-issl/wings/assets/105411820/1fb10d73-cd6c-43c3-a23e-64bcebed3607)


## 影響範囲
小

