### PR TITLE
fix fetchCommandsAction

### DIFF
--- a/aspnetapp/WINGS/ClientApp/src/redux/commands/reducers.ts
+++ b/aspnetapp/WINGS/ClientApp/src/redux/commands/reducers.ts
@@ -12,10 +12,14 @@ export const commandsSlice = createSlice({
       .addCase(Actions.fetchCommandsAction, (state, action) => {
         const commands = action.payload;
         const targets = Array.from(new Set(commands.map(command => command.target)));
+        targets.forEach(target => {
+          if (!(state.targets.includes(target))) state.targets.push(target);
+        })
         const components = Array.from(new Set(commands.map(command => command.component)));
+        components.forEach(component => {
+          if (!(state.components.includes(component))) state.components.push(component);
+        })
         state.list  = commands;
-        state.targets = [...state.targets, ...targets];
-        state.components =  [...state.components, ...components];
         state.logs = [];
       })
       .addCase(Actions.updateCommandLogAction, (state, action) => {


### PR DESCRIPTION
## 概要
commandのtargetとcomponentが重複しないように修正

## 関連PR
- https://github.com/ut-issl/gaia-wings-ui/pull/170

## 詳細
fetchCommandsActionが二回呼び出されることでcomponentsに同じ内容が複数入ってしまうことがあった
これを重複しないものだけpushするように修正した
そのほか軽微な修正

## 検証結果
手元で確認済み

## 影響範囲
小


