### PR TITLE
[bug] modify loading cmd db

### DIFF
--- a/aspnetapp/WINGS/Data/CommandDbRepository.cs
+++ b/aspnetapp/WINGS/Data/CommandDbRepository.cs
@@ -58,7 +58,7 @@ namespace WINGS.Data
         {
           var cols = parser.ReadFields();
           if (parser.LineNumber == 1) { ComponentName = cols[0]; continue; }
-          else if (parser.LineNumber < 5) { continue; }
+          else if (parser.LineNumber < 3) { continue; }
           if (cols.All(x => x == "")) { break; }
           if (cols[0] != "" && cols[0][0] == '*')
           {


### PR DESCRIPTION
## 概要
modify loading cmd db

## 関連PR
- https://gitlab.com/ut_issl/wings/wings/-/merge_requests/282

## 詳細
cmdDBのcsvの中で、5行目までがskipされる設定になっていたため、NOPの行がskipされていた。
三行目までをskip+"*"で始まる行をskipという実装に変更することで解決

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
