### PR TITLE
renovate Grpc.Tools to 2.70.0

### DIFF
--- a/aspnetapp/WINGS/WINGS.csproj
+++ b/aspnetapp/WINGS/WINGS.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="Google.Protobuf" Version="3.29.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.70.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.68.1">
+    <PackageReference Include="Grpc.Tools" Version="2.70.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## 概要
renovate Grpc.Tools to 2.70.0

## Issue
- #58 

## 詳細
#58でGrpc.Net.Clientを更新したが、Grpc.Toolsとのversion不一致が生じたので修正
