### PR TITLE
fix: wait_until がループ中に最新テレメトリを取得できず timeout する不具合を修正

### DIFF
--- a/aspnetapp/WINGS/ClientApp/src/components/command/plan_display/PlanTabPanel.tsx
+++ b/aspnetapp/WINGS/ClientApp/src/components/command/plan_display/PlanTabPanel.tsx
@@ -10,7 +10,7 @@ import { CommandPlanLine, RequestStatus, CmdFileVariable, Telemetry, TlmCmdConfi
 import RequestTableRow from './RequestTableRow';
 import { selectedPlanRowAction, execRequestSuccessAction, execRequestErrorAction, execRequestsStartAction, execRequestsEndAction, editCmdFileVariableAction } from '../../../redux/plans/actions';
 import { getActivePlanId, getAllIndexes, getInExecution, getPlanContents, getSelectedRow, getCommandFileVariables } from '../../../redux/plans/selectors';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 import { openPlan, postCommand, postCommandFileLineLog } from '../../../redux/plans/operations';
 import { RootState } from '../../../redux/store/RootState';
 import { getLatestTelemetries } from '../../../redux/telemetries/selectors';
@@ -47,6 +47,9 @@ const PlanTabPanel = (props: PlanTabPanelProps) => {
   const { value, index, name, content, cmdType } = props;
   const dispatch = useDispatch<AppDispatch>();
   const selector = useSelector((state: RootState) => state);
+  // wait_until などの非同期ループ内では render 時に束縛した selector が古くなるため、
+  // 最新テレメトリはループの各周回で store.getState() から取得する。
+  const store = useStore<RootState>();
 
   const [lastSelectedRow, setLastSelectedRow] = React.useState(-1);
 
@@ -254,7 +257,7 @@ const PlanTabPanel = (props: PlanTabPanelProps) => {
       outcome.isSuccess = true;
     } else if (variableName.indexOf('.') > -1) {
       let tlms: Telemetry[] = [];
-      const latestTelemetries = getLatestTelemetries(selector);
+      const latestTelemetries = getLatestTelemetries(store.getState());
       const variableNameSplitList = variableName.split('.');
       let tlmCmdConfigIndex = 0;
       try {


### PR DESCRIPTION
## 概要

コマンドプラン(.ops)の制御命令 `wait_until` が、実行中に最新テレメトリを取得できず、条件が満たされないまま timeout で失敗する不具合を修正します。

## 根本原因

`wait_until` は `PlanTabPanel.tsx` の `executeControlRequest` 内で、`while` ループ + `await _sleep(1000)` によりテレメトリをポーリングします。値取得は `getVariableValue` → `getLatestTelemetries(selector)` を経由しますが、この `selector` は

```ts
const selector = useSelector((state: RootState) => state);
```

で **render 時点に束縛された Redux state のスナップショット**です。

実行を開始した非同期ループはこの `selector` を**古いクロージャとして掴み続ける**ため、websocket 経由でテレメトリが更新され再 render が起きても、ループ内の参照は更新されません。結果として最新値が反映されず、条件が永遠に成立せず timeout していました。

## 修正内容

`PlanTabPanel.tsx`:

- `react-redux` の `useStore` で**安定した store 参照**を取得。
- `getVariableValue` 内のテレメトリ取得を `getLatestTelemetries(selector)` → `getLatestTelemetries(store.getState())` に変更。

`store.getState()` はレンダリングのタイミングに依存せず、呼び出しの都度**必ず最新の state** を返すため、ループの各周回で live なテレメトリを観測できるようになります。

`getVariableValue` 内で stale になり得る参照はこの1箇所のみ(`tlmCmdConfig` は静的設定)。この変更により `wait_until` に加え、`check_value` / `get` も最新テレメトリを参照するようになります。

## テスト計画

- [ ] `dotnet build` / `react-scripts build`(publish)が成功すること
- [ ] `wait_until <tlm> == <value>` を含む .ops プランを実行し、テレメトリ更新で条件成立時にループが timeout せずに抜けること
- [ ] `wait_until ... -timeoutsec N` で、条件不成立時に指定秒数で正しく timeout すること
- [ ] `wait_until <tlm> in [lower, upper]`(範囲比較)でも最新テレメトリで判定されること

> 本ループの更新はライブテレメトリ + websocket に依存するため自動テストが難しく、実機/実プランでの動作確認を最終検証とします。